### PR TITLE
Fix extraCommandArgs not being copied

### DIFF
--- a/lib/node/closure-compiler.js
+++ b/lib/node/closure-compiler.js
@@ -34,7 +34,7 @@ var contribPath = path.dirname(compilerPath) + '/contrib';
  * @param {Array<String>=} extraCommandArgs
  */
 function Compiler(args, extraCommandArgs) {
-  this.commandArguments = extraCommandArgs || [];
+  this.commandArguments = extraCommandArgs.slice() || [];
 
   this.commandArguments.push('-jar', Compiler.JAR_PATH);
 


### PR DESCRIPTION
Fix extraCommandArgs not being copied https://github.com/ChadKillingsworth/closure-compiler-npm/issues/18