### PR TITLE
Add a .src method to the gulp plugin to support usage without gulp.src

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ gulp.task('js-compile', function () {
         output_wrapper: '(function(){\n%output%\n}).call(this)',
         js_output_file: 'output.min.js'
       })
+      .src() // needed to force the plugin to run without gulp.src
       .pipe(gulp.dest('./dist/js'));
 });
 ```
@@ -241,30 +242,8 @@ gulp.task('js-compile', function () {
         '--js_output_file', 'out.js',
         '--debug'
       ])
+      .src() // needed to force the plugin to run without gulp.src
       .pipe(gulp.dest('./dist/js'));
-});
-```
-
-### Requiring gulp.src files for compilation
-By default, the gulp plugin will run the compiler even if no input is streamed in via `gulp.src`.
-To disable this behavior, users can specify a { requireStreamInput: true } argument to skip
-compilation if no files are streamed in. This allows interoperation with gulp plugins that signal
-through empty streams.
-
-```js
-var closureCompiler = require('google-closure-compiler').gulp({
-  requireStreamInput: true
-});
-var newer = require('gulp-newer');
-
-gulp.task('js-compile', function () {
-  return gulp.src('./src/js/**/*.js', {base: './'})
-      .pipe(newer('./dist/output.min.js'))
-      .pipe(closureCompiler({
-          compilation_level: 'ADVANCED',
-          js_output_file: 'output.min.js'
-        }))
-      .pipe(gulp.dest('./dist'));
 });
 ```
 

--- a/lib/grunt/index.js
+++ b/lib/grunt/index.js
@@ -36,7 +36,8 @@ module.exports = function(grunt, extraArguments) {
   var gulpCompilerOptions = {
     streamMode: 'IN',
     logger: grunt.log,
-    pluginName: 'grunt-google-closure-compiler'
+    pluginName: 'grunt-google-closure-compiler',
+    requireStreamInput: false
   };
 
   /**

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -42,7 +42,7 @@ module.exports = function(initOptions) {
   var stream = require('stream');
   /** @const */
   var PLUGIN_NAME = 'gulp-google-closure-compiler';
-  var streamInputRequired = initOptions ? !!initOptions.requireStreamInput : false;
+
   var extraCommandArguments = initOptions ? initOptions.extraArguments : undefined;
   var SourceMapGenerator = require('source-map').SourceMapGenerator;
   var SourceMapConsumer = require('source-map').SourceMapConsumer;
@@ -61,9 +61,22 @@ module.exports = function(initOptions) {
     this.PLUGIN_NAME_ = pluginOptions.pluginName || PLUGIN_NAME;
 
     this.fileList_ = [];
-
+    this._streamInputRequired = pluginOptions.requireStreamInput !== false;
   }
   CompilationStream.prototype = Object.create(stream.Transform.prototype);
+
+  // Buffer the files into an array
+  CompilationStream.prototype.src = function() {
+    this._streamInputRequired = false;
+    process.nextTick((function() {
+      var stdInStream = new stream.Readable({ read: function() {
+        return new gutil.File();
+      }});
+       stdInStream.pipe(this);
+       stdInStream.push(null);
+     }).bind(this));
+    return this;
+  };
 
   // Buffer the files into an array
   CompilationStream.prototype._transform = function(file, enc, cb) {
@@ -80,7 +93,6 @@ module.exports = function(initOptions) {
     }
 
     this.fileList_.push(file);
-
     cb();
   };
 
@@ -91,7 +103,7 @@ module.exports = function(initOptions) {
       jsonFiles = filesToJson(this.fileList_);
     } else {
       // If files in the stream were required, no compilation needed here.
-      if (streamInputRequired) {
+      if (this._streamInputRequired) {
         this.emit('end');
         cb();
         return;

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -220,13 +220,12 @@ describe('gulp-google-closure-compiler', function() {
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE'
           })
+          .src()
           .pipe(assert.length(1))
           .pipe(assert.first(function(f) {
-            f.contents.toString().should.eql('function log(a){console.log(a)}log("one.js");log("two.js");\n');
+            f.contents.toString().should.eql(fixturesCompiled);
           }))
           .pipe(assert.end(done));
-
-      stream.end();
     });
 
     it('should include js options before gulp.src files', function(done) {
@@ -255,28 +254,7 @@ describe('gulp-google-closure-compiler', function() {
             '--compilation_level=SIMPLE',
             '--warning_level=VERBOSE'
           ])
-          .pipe(assert.length(1))
-          .pipe(assert.first(function(f) {
-            f.contents.toString().should.eql(fixturesCompiled);
-          }))
-          .pipe(assert.end(done));
-
-      stream.end();
-    });
-
-    it('should compile gulp.src files when stream input is required', function(done) {
-      this.timeout(30000);
-      this.slow(10000);
-
-      var streamRequiredCompiler = compilerPackage.gulp({
-        requireStreamInput: true
-      });
-
-      gulp.src(__dirname + '/fixtures/**.js')
-          .pipe(streamRequiredCompiler({
-            compilation_level: 'SIMPLE',
-            warning_level: 'VERBOSE'
-          }))
+          .src()
           .pipe(assert.length(1))
           .pipe(assert.first(function(f) {
             f.contents.toString().should.eql(fixturesCompiled);
@@ -284,17 +262,30 @@ describe('gulp-google-closure-compiler', function() {
           .pipe(assert.end(done));
     });
 
-    it('should generate no output without gulp.src files when stream input is required', function(done) {
-      var streamRequiredCompiler = compilerPackage.gulp({
-        requireStreamInput: true
-      });
-
+    it('should generate no output without gulp.src files', function(done) {
       gulp.src([])
-          .pipe(streamRequiredCompiler({
+          .pipe(closureCompiler({
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE'
           }))
           .pipe(assert.length(0))
+          .pipe(assert.end(done));
+    });
+
+    it('should compile without gulp.src files when .src() is called', function(done) {
+      this.timeout(30000);
+      this.slow(10000);
+
+      closureCompiler({
+            compilation_level: 'SIMPLE',
+            warning_level: 'VERBOSE',
+            js: __dirname + '/fixtures/**.js'
+          })
+          .src()
+          .pipe(assert.length(1))
+          .pipe(assert.first(function(f) {
+            f.contents.toString().should.eql(fixturesCompiled);
+          }))
           .pipe(assert.end(done));
     });
 


### PR DESCRIPTION
Fixes #16 

@Dominator008 Have time to look at this?