### PR TITLE
Wait for the 'end' event on stdout/err before writing out the messages

### DIFF
--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -119,11 +119,28 @@ module.exports = function(initOptions) {
     compilerProcess.stderr.on('data', function (data) {
       stdErrData += data;
     });
-    compilerProcess.on('close', (function (code) {
+
+    Promise.all([
+      new Promise(function(resolve) {
+        compilerProcess.on('close', function(code) {
+          resolve(code);
+        });
+      }),
+      new Promise(function(resolve) {
+        compilerProcess.stdout.on('end', function() {
+          resolve();
+        });
+      }),
+      new Promise(function(resolve) {
+        compilerProcess.stderr.on('end', function() {
+          resolve();
+        });
+      })
+    ]).then((function(results) {
+      var code = results[0];
       // non-zero exit means a compilation error
       if (code !== 0) {
-        this.emit('error', new PluginError(this.PLUGIN_NAME_,
-            'Compilation error: \n\n' + compiler.prependFullCommand(stdErrData)));
+        this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Compilation error'));
       }
 
       // standard error will contain compilation warnings, log those

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -53,7 +53,7 @@ describe('gulp-google-closure-compiler', function() {
       });
 
       stream.on('error', function (err) {
-        err.message.should.startWith('Compilation error:');
+        err.message.should.startWith('Compilation error');
         done();
       });
       stream.write(fakeFile1);


### PR DESCRIPTION
Fixes #24 

The `close` event for the spawned process can occur before the `end` events for standard out and error streams - thus truncating any messages being written. Wait for the `end` of both streams AND the `close` event on the spawned process before triggering the after compilation logic.