### PR TITLE
Write out standard error before exiting on errors

### DIFF
--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -150,14 +150,15 @@ module.exports = function(initOptions) {
       })
     ]).then((function(results) {
       var code = results[0];
-      // non-zero exit means a compilation error
-      if (code !== 0) {
-        this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Compilation error'));
-      }
 
       // standard error will contain compilation warnings, log those
       if (stdErrData.trim().length > 0) {
         logger(gutil.colors.yellow(this.PLUGIN_NAME_) + ': ' + stdErrData);
+      }
+
+      // non-zero exit means a compilation error
+      if (code !== 0) {
+        this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Compilation error'));
       }
 
       // If present, standard output will be a string of JSON encoded files.


### PR DESCRIPTION
Specific to the gulp plugin: log the error data before emitting the error event so that they are seen before the process exits.