### PR TITLE
Fix a bug which was passing input source maps in on a misnamed property

### DIFF
--- a/lib/gulp/concat-to-json.js
+++ b/lib/gulp/concat-to-json.js
@@ -33,7 +33,7 @@ function json_file(src, path, source_map) {
   }
 
   if (source_map) {
-    filejson.source_map = source_map;
+    filejson.sourceMap = source_map;
   }
 
   return filejson;

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -182,11 +182,11 @@ module.exports = function(initOptions) {
             outputFiles[i].sourceMap = undefined;
 
             for (var j = 0; j < jsonFiles.length; j++) {
-              if (!jsonFiles[j].source_map) {
+              if (!jsonFiles[j].sourceMap) {
                 continue;
               }
               generator.applySourceMap(
-                  new SourceMapConsumer(jsonFiles[j].source_map),
+                  new SourceMapConsumer(jsonFiles[j].sourceMap),
                   jsonFiles[j].path.substr(1));
             }
             applySourceMap(outputFiles[i], generator.toString());

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -306,8 +306,7 @@ describe('gulp-google-closure-compiler', function() {
             module: [
                 'three:1',
                 'four:1:three'
-            ],
-            module_output_path_prefix: 'build/'
+            ]
           }))
           .pipe(closureCompiler({
             compilation_level: 'SIMPLE',


### PR DESCRIPTION
While testing google/closure-compiler#1971, I found a bug where input sourcemaps were being passed into the compiler on a misnamed property. Thus the plugin is currently not providing input sourcemaps at all.

This fixes the issue.