### PR TITLE
Replace travis tests with Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
+- '7'
 - '6'
-- '5'
 - '0.12'
 branches:
   only:


### PR DESCRIPTION
Node 5 is no longer supported. Switch to testing against Node 7.