### PR TITLE
Reduce Dependencies

### DIFF
--- a/lib/grunt/index.js
+++ b/lib/grunt/index.js
@@ -27,8 +27,8 @@
 'use strict';
 
 module.exports = function(grunt, extraArguments) {
-  var chalk = require('gulp-util').colors;
-  var vinylfs = require('vinyl-fs');
+  var chalk = require('chalk');
+  var VinylStream = require('./vinyl-stream');
   var fs = require('fs');
   var path = require('path');
   var gulpCompiler = require('../gulp')({extraArguments: extraArguments});
@@ -71,8 +71,8 @@ module.exports = function(grunt, extraArguments) {
         // Source files were provided by grunt. Read these
         // in to a stream of vinyl files and pipe them through
         // the compiler task
-        stream = vinylfs.src(files, {base: process.cwd()})
-            .pipe(gulpCompiler(options, gulpCompilerOptions))
+        stream = new VinylStream(files, {base: process.cwd()})
+            .pipe(gulpCompiler(options, gulpCompilerOptions));
       } else {
         // No source files were provided. Assume the options specify
         // --js flags and invoke the compiler without any grunt inputs.

--- a/lib/grunt/vinyl-stream.js
+++ b/lib/grunt/vinyl-stream.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Class to convert an array of file paths to
+ * as stream of Vinyl files.
+ *
+ * @author Chad Killingsworth (chadkillingsworth@gmail.com)
+ */
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Readable = require('stream').Readable;
+var File = require('vinyl');
+
+function VinylStream(files, opts) {
+  Readable.call(this, {objectMode: true});
+  this._base = path.resolve(opts.base || process.cwd());
+  this._files = files.slice();
+  this.resume();
+}
+VinylStream.prototype = Object.create(Readable.prototype);
+
+VinylStream.prototype._read = function() {
+  if (this._files.length === 0) {
+    this.emit('end');
+    return;
+  }
+  this.readFile();
+};
+
+VinylStream.prototype.readFile = function() {
+  if (this._files.length === 0) {
+    return;
+  }
+  var filepath = this._files.shift();
+  var fullpath = path.resolve(this._base, filepath);
+  fs.readFile(fullpath, (function (fullpath, err, data) {
+    if (err) {
+      this.emit('error', err);
+      return;
+    }
+
+    var file = new File({
+      base: this._base,
+      path: fullpath,
+      contents: data
+    });
+
+    if (!this.push(file)) {
+      return;
+    } else {
+      this.readFile();
+    }
+  }).bind(this, fullpath));
+};
+
+module.exports = VinylStream;

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -28,7 +28,6 @@
 
 'use strict';
 
-
 /**
  * @param {Object<string,string>} initOptions
  * @return {function(Object<string,string>|Array<string>):Object}
@@ -37,8 +36,6 @@ module.exports = function(initOptions) {
   var filesToJson = require('./concat-to-json');
   var jsonToVinyl = require('./json-to-vinyl');
   var Compiler = require('../node/closure-compiler');
-  var gutil = require('gulp-util');
-  var PluginError = gutil.PluginError;
   var stream = require('stream');
   /** @const */
   var PLUGIN_NAME = 'gulp-google-closure-compiler';
@@ -46,7 +43,33 @@ module.exports = function(initOptions) {
   var extraCommandArguments = initOptions ? initOptions.extraArguments : undefined;
   var applySourceMap = require('vinyl-sourcemaps-apply');
   var path = require('path');
+  var chalk = require('chalk');
+  var File = require('vinyl');
 
+  /** @constructor */
+  function CustomError(plugin, msg) {
+    var superError = Error.call(this) || this;
+    Error.captureStackTrace(superError, this.constructor);
+    superError.name = 'Error';
+    superError.message = msg;
+    return superError;
+  }
+  CustomError.prototype = Object.create(Error.prototype);
+  CustomError.prototype.name = 'Error';
+
+  var PluginError;
+  try {
+    PluginError = require('gulp-util').PluginError;
+  } catch(e) {
+    PluginError = CustomError;
+  }
+
+  var gulpLog;
+  try {
+    gulpLog = require('gulp-util').log;
+  } catch(e) {
+    gulpLog = console;
+  }
 
   function CompilationStream(compilationOptions, pluginOptions) {
     stream.Transform.call(this, {objectMode: true});
@@ -55,7 +78,7 @@ module.exports = function(initOptions) {
 
     this.compilatonOptions_ = compilationOptions;
     this.streamMode_ = pluginOptions.streamMode || 'BOTH';
-    this.logger_ = pluginOptions.logger || gutil.log;
+    this.logger_ = pluginOptions.logger || gulpLog;
     this.PLUGIN_NAME_ = pluginOptions.pluginName || PLUGIN_NAME;
 
     this.fileList_ = [];
@@ -68,11 +91,11 @@ module.exports = function(initOptions) {
     this._streamInputRequired = false;
     process.nextTick((function() {
       var stdInStream = new stream.Readable({ read: function() {
-        return new gutil.File();
+        return new File();
       }});
-       stdInStream.pipe(this);
-       stdInStream.push(null);
-     }).bind(this));
+      stdInStream.pipe(this);
+      stdInStream.push(null);
+    }).bind(this));
     return this;
   };
 
@@ -151,7 +174,7 @@ module.exports = function(initOptions) {
 
       // standard error will contain compilation warnings, log those
       if (stdErrData.trim().length > 0) {
-        logger(gutil.colors.yellow(this.PLUGIN_NAME_) + ': ' + stdErrData);
+        logger(chalk.yellow(this.PLUGIN_NAME_) + ': ' + stdErrData);
       }
 
       // non-zero exit means a compilation error

--- a/lib/gulp/json-to-vinyl.js
+++ b/lib/gulp/json-to-vinyl.js
@@ -23,8 +23,7 @@
 
 'use strict';
 
-var gutil = require('gulp-util');
-var File = gutil.File;
+var File = require('vinyl');
 var path = require('path');
 
 /**

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   "homepage": "https://developers.google.com/closure/compiler/",
   "dependencies": {
     "chalk": "^1.0.0",
-    "gulp-util": "^3.0.7",
-    "vinyl-fs": "^2.2.1",
+    "vinyl": "^1.2.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {
@@ -58,6 +57,6 @@
     "pretest": "./build_compiler.js"
   },
   "engines": {
-    "node" : ">=0.12.0"
+    "node": ">=0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-closure-compiler",
-  "version": "20161024.1.0",
+  "version": "20161024.2.0",
   "description": "Check, compile, optimize and compress Javascript with Closure-Compiler",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[vinyl-fs]() and [gulp-util]() end up importing a huge dependency tree.

vinyl-fs was used by the grunt plugin, but only a very small feature set was needed. Replaced with a custom written class.

gulp-util is used for custom error classes and logging. If it exists (because gulp is present), use that. Otherwise use the provided fallbacks.

Alleviates #47 and #41